### PR TITLE
Asian Modelica Conference

### DIFF
--- a/_2019-03/Asian Modelica Conference
+++ b/_2019-03/Asian Modelica Conference
@@ -1,0 +1,10 @@
+title: Asian Modelica Conference
+author: Jocelyn Paslowski, Modelon
+category: Conference and user meetings
+
+
+Previously known as the Japanese Modelica Conference, the Asian Modelica Conference 2020, will be held at Nihonbashi Takashimaya Mitsui Building, Tokyo, Japan from May 13–14, 2020.
+
+The Call for Papers is now available and the deadline for submission is January 31, 2020. For guidelines on paper submissions review the conference website, here.
+
+This conference is organized by Modelon in cooperation with the Modelica Association.

--- a/_2019-03/Asian_Modelica_Conference.md
+++ b/_2019-03/Asian_Modelica_Conference.md
@@ -1,7 +1,10 @@
+---
 title: Asian Modelica Conference
-author: Jocelyn Paslowski, Modelon
+author: [Jocelyn Paslowski, Modelon](https://www.modelon.com/)
 category: "conference"
+---
 
+![](asian_conference.png)
 
 Previously known as the Japanese Modelica Conference, the Asian Modelica Conference 2020, will be held at Nihonbashi Takashimaya Mitsui Building, Tokyo, Japan from May 13–14, 2020.
 

--- a/_2019-03/Asian_Modelica_Conference.md
+++ b/_2019-03/Asian_Modelica_Conference.md
@@ -1,6 +1,6 @@
 title: Asian Modelica Conference
 author: Jocelyn Paslowski, Modelon
-category: Conference and user meetings
+category: "conference"
 
 
 Previously known as the Japanese Modelica Conference, the Asian Modelica Conference 2020, will be held at Nihonbashi Takashimaya Mitsui Building, Tokyo, Japan from May 13–14, 2020.


### PR DESCRIPTION
![Asian Modelica Conference 2020](https://user-images.githubusercontent.com/37085155/68779676-11b58a00-0603-11ea-9a51-8f1d57be94cb.png)

Previously known as the Japanese Modelica Conference, the Asian Modelica Conference 2020, will be held at Nihonbashi Takashimaya Mitsui Building, Tokyo, Japan from May 13–14, 2020.

The Call for Papers is now available and the deadline for submission is January 31, 2020. For guidelines on paper submissions review the conference website,[ here.](https://2020.asian.conference.modelica.org/)

This conference is organized by[ Modelon](www.modelon.com) in cooperation with the [Modelica Association.](https://www.modelica.org/)
