### PR TITLE
Fix Link syntax typo in MBI-LLC-news.md

### DIFF
--- a/_2025-02/MBI-LLC-news.md
+++ b/_2025-02/MBI-LLC-news.md
@@ -16,7 +16,7 @@ For [orchideo \| easySSP](https://www.exxcellent.de/orchideo-easy-ssp) we now of
 
 In the combination of these tools, this covers needs for standards-based system simulation for everything from small customers to enterprise needs. 
 
-#### [Libraries]((https://modelbased.cloud/libraries/)
+#### [Libraries](https://modelbased.cloud/libraries/)
 
 For Libraries, our main Modelica platform is Modelon Impact, but we work with other tools as well, especially for open-source libraries, and extending open-source libraries. MBI has adapted some open source libraries to fully work with Modelon Impact. For example, we have adapted the [Industrial Control Systems Library](https://github.com/hubertus65/IndustrialControlSystems) for Modelon Impact and provide support for it. Further libraries are in preparation.  
 


### PR DESCRIPTION
Dear Modelica Newsletter team,

I noticed a small glitch in the [Vendor / MBI section](https://newsletter.modelica.org/2025-02/index.html#model-based-innovation-mbi-updates) of the 2025-02 newsletter.

The "Libraries" header link was broken due to one extraneous parenthesis